### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # ---------------------------------------------------------------------
 # CPLEX options 
 # ---------------------------------------------------------------------
-CPLEXDIR      = /usr/local/cplex/ILOG/CPLEX_Studio_AcademicResearch122/cplex
-CONCERTDIR    = /usr/local/cplex/ILOG/CPLEX_Studio_AcademicResearch122/concert
+CPLEXDIR      = /usr/local/cplex/ILOG/CPLEX_Studio125/cplex
+CONCERTDIR    = /usr/local/cplex/ILOG/CPLEX_Studio125/concert
 SYSTEM = x86-64_sles10_4.1
 LIBFORMAT = static_pic
 


### PR DESCRIPTION
Updates Makefile for use on updated Iowa State servers (a new version of CPLEX was installed). This is probably an arbitrary option since the CPLEX path is going to vary by installation, but since Iowa State is currently the only place that this is used, it may be good for Netplan to compile right out of the box.
