### PR TITLE
Update headers for gcc 4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # ---------------------------------------------------------------------
 # CPLEX options 
 # ---------------------------------------------------------------------
-CPLEXDIR      = /usr/local/cplex/ILOG/CPLEX_Studio_AcademicResearch122/cplex
-CONCERTDIR    = /usr/local/cplex/ILOG/CPLEX_Studio_AcademicResearch122/concert
+CPLEXDIR      = /usr/local/cplex/ILOG/CPLEX_Studio125/cplex
+CONCERTDIR    = /usr/local/cplex/ILOG/CPLEX_Studio125/concert
 SYSTEM = x86-64_sles10_4.1
 LIBFORMAT = static_pic
 

--- a/src/arc.cpp
+++ b/src/arc.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "global.h"
 #include "arc.h"
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -8,6 +8,7 @@ using namespace std;
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <cstring>
 #include <time.h>
 #include <math.h>
 extern int outputLevel;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "global.h"
 #include "index.h"
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "global.h"
 #include "node.h"
 

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -9,6 +9,8 @@ using namespace std;
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
+#include <cstring>
 #include "global.h"
 #include "read.h"
 

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "global.h"
 
 // Converts a string like 'y1m2' into the appropriate 'Step' (vector of integers)


### PR DESCRIPTION
GCC 4.4 (just installed on ISU remote-access servers) requires cstdlib and cstring to be included explicitly.
